### PR TITLE
Add type annotations

### DIFF
--- a/phase3/environmentClass.py
+++ b/phase3/environmentClass.py
@@ -1,26 +1,29 @@
 from commClass import Comms
-from estimatorClass import centralEstimator, ciEstimator, etEstimator, indeptEstimator
+from estimatorClass import CentralEstimator
+from estimatorClass import CiEstimator
+from estimatorClass import EtEstimator
+from estimatorClass import IndeptEstimator
 from import_libraries import *
+from sensorClass import Sensor
+from targetClass import Target
 
 # Import classes
-from satelliteClass import satellite
-from sensorClass import sensor
-from targetClass import target
+from phase3 import satelliteClass
 
 ## Creates the environment class, which contains a vector of satellites all other parameters
 
 
-class environment:
+class Environment:
     def __init__(
         self,
-        sats,
+        sats: list[satelliteClass.Satellite],
         targs,
         comms,
         commandersIntent,
-        localEstimatorBool,
-        centralEstimatorBool,
-        ciEstimatorBool,
-        etEstimatorBool,
+        localEstimatorBool: bool,
+        centralEstimatorBool: bool,
+        ciEstimatorBool: bool,
+        etEstimatorBool: bool,
     ):
         """
         Initialize an environment object with satellites, targets, communication network, and optional central estimator.
@@ -44,24 +47,24 @@ class environment:
             # Create estimation algorithms for each satellite
             self.localEstimatorBool = localEstimatorBool
             if localEstimatorBool:
-                sat.indeptEstimator = indeptEstimator(
+                sat.indeptEstimator = IndeptEstimator(
                     commandersIntent[0][sat]
                 )  # initialize the independent estimator for these targets
 
             self.centralEstimatorBool = centralEstimatorBool
             if centralEstimatorBool:
-                self.centralEstimator = centralEstimator(
+                self.centralEstimator = CentralEstimator(
                     commandersIntent[0][sat]
                 )  # initialize the central estimator for these targets
 
             self.ciEstimatorBool = ciEstimatorBool
             if ciEstimatorBool:
-                sat.ciEstimator = ciEstimator(commandersIntent[0][sat])
+                sat.ciEstimator = CiEstimator(commandersIntent[0][sat])
 
             self.etEstimatorBool = etEstimatorBool
             if etEstimatorBool:
                 sat.etEstimators = [
-                    etEstimator(commandersIntent[0][sat], shareWith=None)
+                    EtEstimator(commandersIntent[0][sat], shareWith=None)
                 ]
 
         ## Populate the environment variables
@@ -648,6 +651,7 @@ class environment:
                     ):
                         # This means satellite has a measurement for this target, now send it to neighbors
                         for neighbor in self.comms.G.neighbors(sat):
+                            neighbor: satelliteClass.Satellite
                             # If target is not in neighbors priority list, skip
                             if targetID not in neighbor.targPriority.keys():
                                 continue
@@ -669,7 +673,7 @@ class environment:
                             if (
                                 commonEKF is None
                             ):  # or make a common filter if one doesn't exist
-                                commonEKF = etEstimator(
+                                commonEKF = EtEstimator(
                                     local_EKF.targetPriorities, shareWith=neighbor.name
                                 )
                                 commonEKF.et_EKF_initialize(target, envTime)
@@ -698,7 +702,7 @@ class environment:
                             if (
                                 commonEKF is None
                             ):  # if I don't, create one and add it to etEstimators list
-                                commonEKF = etEstimator(
+                                commonEKF = EtEstimator(
                                     neighbor.targPriority, shareWith=sat.name
                                 )
                                 commonEKF.et_EKF_initialize(target, envTime)

--- a/phase3/main.py
+++ b/phase3/main.py
@@ -1,13 +1,16 @@
 # Import pre-defined libraries
-from commClass import comms
+from commClass import Comms
 
 # Import classes
-from environmentClass import environment
-from estimatorClass import centralEstimator, ciEstimator, etEstimator, indeptEstimator
+from environmentClass import Environment
+from estimatorClass import CentralEstimator
+from estimatorClass import CiEstimator
+from estimatorClass import EtEstimator
+from estimatorClass import IndeptEstimator
 from import_libraries import *
-from satelliteClass import satellite
-from sensorClass import sensor
-from targetClass import target
+from satelliteClass import Satellite
+from sensorClass import Sensor
+from targetClass import Target
 
 
 ### This environment is used for the base case, with 12 satellites, all with different track qualitys being tracked by 4 satellites from 2 different constellations
@@ -27,7 +30,7 @@ def create_environment():
     targ5_color = '#b228b4'
 
     # Define the targets
-    targ1 = target(
+    targ1 = Target(
         name='Targ1',
         tqReq=1,
         targetID=1,
@@ -37,7 +40,7 @@ def create_environment():
         uncertainty=np.array([3, 7.5, 0, 90, 0.1]),
         color=targ1_color,
     )
-    targ2 = target(
+    targ2 = Target(
         name='Targ2',
         tqReq=2,
         targetID=2,
@@ -47,7 +50,7 @@ def create_environment():
         uncertainty=np.array([3, 7.5, 0, 90, 0.1]),
         color=targ2_color,
     )
-    targ3 = target(
+    targ3 = Target(
         name='Targ3',
         tqReq=3,
         targetID=3,
@@ -57,7 +60,7 @@ def create_environment():
         uncertainty=np.array([3, 7.5, 0, 90, 0.1]),
         color=targ3_color,
     )
-    targ4 = target(
+    targ4 = Target(
         name='Targ4',
         tqReq=4,
         targetID=4,
@@ -67,7 +70,7 @@ def create_environment():
         uncertainty=np.array([3, 7.5, 0, 90, 0.1]),
         color=targ4_color,
     )
-    targ5 = target(
+    targ5 = Target(
         name='Targ5',
         tqReq=5,
         targetID=5,
@@ -81,14 +84,14 @@ def create_environment():
     targs = [targ1, targ2, targ3, targ4, targ5]
 
     # Define the satellite structure:
-    sens_good = sensor(
+    sens_good = Sensor(
         name='Sensor', fov=115, bearingsError=np.array([115 * 0.01, 115 * 0.01])
     )  # 1% error on FOV bearings
-    sens_bad = sensor(
+    sens_bad = Sensor(
         name='Sensor', fov=115, bearingsError=np.array([115 * 0.1, 115 * 0.1])
     )  # 10% error on FOV bearings
 
-    sat1a = satellite(
+    sat1a = Satellite(
         name='Sat1a',
         sensor=deepcopy(sens_good),
         a=Earth.R + 1000 * u.km,
@@ -99,7 +102,7 @@ def create_environment():
         nu=0,
         color='#669900',
     )
-    sat1b = satellite(
+    sat1b = Satellite(
         name='Sat1b',
         sensor=deepcopy(sens_good),
         a=Earth.R + 1000 * u.km,
@@ -110,7 +113,7 @@ def create_environment():
         nu=0,
         color='#66a3ff',
     )
-    sat2a = satellite(
+    sat2a = Satellite(
         name='Sat2a',
         sensor=deepcopy(sens_bad),
         a=Earth.R + 1000 * u.km,
@@ -121,7 +124,7 @@ def create_environment():
         nu=0,
         color='#9966ff',
     )
-    sat2b = satellite(
+    sat2b = Satellite(
         name='Sat2b',
         sensor=deepcopy(sens_bad),
         a=Earth.R + 1000 * u.km,
@@ -160,7 +163,7 @@ def create_environment():
     et = False
 
     # Define the communication network:
-    comms_network = comms(
+    comms_network = Comms(
         sats,
         maxBandwidth=60,
         maxNeighbors=3,
@@ -170,7 +173,7 @@ def create_environment():
     )
 
     # Create and return an environment instance:
-    return environment(
+    return Environment(
         sats,
         targs,
         comms_network,

--- a/phase3/satelliteClass.py
+++ b/phase3/satelliteClass.py
@@ -1,25 +1,37 @@
 from import_libraries import *
 
+from phase3 import estimatorClass
+from phase3 import sensorClass
+from phase3 import targetClass
+
 ## Creates the satellite class, will contain the poliastro orbit and all other parameters needed to define the orbit
 
 
-class satellite:
-    def __init__(self, a, ecc, inc, raan, argp, nu, sensor, name, color):
+class Satellite:
+    def __init__(
+        self,
+        a: float,
+        ecc: float,
+        inc: float,
+        raan: float,
+        argp: float,
+        nu: float,
+        sensor: sensorClass.Sensor,
+        name: str,
+        color: str,
+    ):
         """Initialize a Satellite object.
 
         Args:
-            a (float or int): Semi-major axis of the satellite's orbit.
-            ecc (float or int): Eccentricity of the satellite's orbit.
-            inc (float or int): Inclination of the satellite's orbit in degrees.
-            raan (float or int): Right ascension of the ascending node in degrees.
-            argp (float or int): Argument of periapsis in degrees.
-            nu (float or int): True anomaly in degrees.
-            sensor (object): Sensor used by the satellite.
-            target_ids (list): List of target IDs to track.
-            indept_estimator (object): Independent estimator for benchmarking.
-            name (str): Name of the satellite.
-            color (str): Color of the satellite for visualization.
-            ddf_estimator (object, optional): DDF estimator to test. Defaults to None.
+            a: Semi-major axis of the satellite's orbit.
+            ecc: Eccentricity of the satellite's orbit.
+            inc: Inclination of the satellite's orbit in degrees.
+            raan: Right ascension of the ascending node in degrees.
+            argp: Argument of periapsis in degrees.
+            nu: True anomaly in degrees.
+            sensor: Sensor used by the satellite.
+            name: Name of the satellite.
+            color: Color of the satellite for visualization.
         """
 
         # Sensor to use
@@ -30,9 +42,9 @@ class satellite:
         self.color = color
 
         # Set the estimators to None on initalization
-        self.indeptEstimator = None
-        self.ciEstimator = None
-        self.etEstimators = None
+        self.indeptEstimator: estimatorClass.IndeptEstimator | None = None
+        self.ciEstimator: estimatorClass.CiEstimator | None = None
+        self.etEstimators: list[estimatorClass.EtEstimator] | None = None
 
         # Create the orbit
         # Check if already in units, if not convert
@@ -63,7 +75,7 @@ class satellite:
         self.velHist = defaultdict(dict)  # contains time and xyz of velocity history
         self.time = 0
 
-    def collect_measurements_and_filter(self, target):
+    def collect_measurements_and_filter(self, target: targetClass.Target) -> bool:
         """
         Collect measurements from the sensor for a specified target and update local filters.
         The satellite will use its sensor class to collect a measurement on the target.
@@ -71,10 +83,10 @@ class satellite:
         Updating the local filters calls the EKF functions to update the state and covariance estimates based on the measurement.
 
         Args:
-            target (object): Target object containing targetID and other relevant information.
+            target: Target object containing targetID and other relevant information.
 
         Returns:
-            int: Flag indicating whether measurements were successfully collected (1) or not (0).
+            Flag indicating whether measurements were successfully collected (1) or not (0).
         """
 
         # Assume no measurement is collected on this target
@@ -104,7 +116,9 @@ class satellite:
 
             return collectedFlag
 
-    def update_indept_estimator(self, measurement, target, time):
+    def update_indept_estimator(
+        self, measurement, target: targetClass.Target, time: float
+    ) -> None:
         """Update the independent estimator for the satellite.
 
         The satellite will update its independent estimator using the measurement provided.
@@ -124,7 +138,9 @@ class satellite:
         self.indeptEstimator.local_EKF_pred(targetID, time)
         self.indeptEstimator.local_EKF_update([self], [measurement], targetID, time)
 
-    def update_ci_estimator(self, measurement, target, time):
+    def update_ci_estimator(
+        self, measurement, target: targetClass.Target, time: float
+    ) -> None:
         """Update the DDF estimator for the satellite.
 
         The satellite will update its DDF estimator using the measurement provided.
@@ -147,7 +163,9 @@ class satellite:
         self.ciEstimator.ci_EKF_pred(targetID, time)
         self.ciEstimator.ci_EKF_update([self], [measurement], targetID, time)
 
-    def update_et_estimator(self, measurement, target, time):
+    def update_et_estimator(
+        self, measurement, target: targetClass.Target, time: float
+    ) -> None:
         """Update the ET filters for the satellite.
 
         The satellite will update its ET filters using the measurement provided.

--- a/phase3/sensorClass.py
+++ b/phase3/sensorClass.py
@@ -1,21 +1,33 @@
 from import_libraries import *
+from jax import typing as jnpt
+from numpy import typing as npt
+
+from phase3 import satelliteClass
+from phase3 import targetClass
 
 
-class sensor:
+class Sensor:
     """
     Class representing a bearings only sensor.
     """
 
-    def __init__(self, fov, bearingsError, name, detectChance=0, resolution=720):
+    def __init__(
+        self,
+        fov: float,
+        bearingsError: float,
+        name: str,
+        detectChance: float = 0,
+        resolution: int = 720,
+    ):
         """
         Initialize a sensor instance.
 
         Args:
-            fov (float): Field of view of the sensor [deg].
-            bearingsError (float): Error associated with bearings [deg].
-            name (str): Name of the sensor.
-            detectChance (float, optional): Detection probability chance (default is 0).
-            resolution (int, optional): Resolution of the sensor (default is 720).
+            fov: Field of view of the sensor [deg].
+            bearingsError: Error associated with bearings [deg].
+            name: Name of the sensor.
+            detectChance: Detection probability chance (default is 0).
+            resolution: Resolution of the sensor (default is 720).
         """
         self.fov = fov
         self.bearingsError = bearingsError
@@ -24,16 +36,18 @@ class sensor:
         self.resolution = resolution
         self.projBox = np.array([0, 0, 0])
 
-    def get_measurement(self, sat, targ):
+    def get_measurement(
+        self, sat: satelliteClass.Satellite, targ: targetClass.Target
+    ) -> npt.NDArray | None:
         """
         Get sensor measurement of a target if visible within sensor's field of view.
 
         Args:
-            sat (Satellite): Satellite object.
-            targ (Target): Target object.
+            sat: Satellite object.
+            targ: Target object.
 
         Returns:
-            np.ndarray: Sensor measurement if target is visible, else returns 0.
+            Sensor measurement if target is visible, else returns None.
         """
 
         # Get the current projection box of the sensor
@@ -51,16 +65,18 @@ class sensor:
         else:
             return None
 
-    def sensor_model(self, sat, targ):
+    def sensor_model(
+        self, sat: satelliteClass.Satellite, targ: targetClass.Target
+    ) -> npt.NDArray:
         """
         Simulate sensor measurement with added error.
 
         Args:
-            sat (Satellite): Satellite object.
-            targ (Target): Target object.
+            sat: Satellite object.
+            targ: Target object.
 
         Returns:
-            np.ndarray: Simulated sensor measurement (in-track and cross-track angles).
+            Simulated sensor measurement (in-track and cross-track angles).
         """
         # Get True Relative Target Position in terms of bearings angles
         in_track_truth, cross_track_truth = self.convert_to_bearings(sat, targ.pos)
@@ -74,16 +90,18 @@ class sensor:
         # Return the noisy sensor measurement
         return np.array([in_track_meas, cross_track_meas])
 
-    def convert_to_bearings(self, sat, meas_ECI):
+    def convert_to_bearings(
+        self, sat: satelliteClass.Satellite, meas_ECI: npt.NDArray
+    ) -> tuple[float, float]:
         """
         Convert satellite and target ECI positions to bearings angles.
 
         Args:
-            sat (Satellite): Satellite object.
-            meas_ECI (np.ndarray): Target position vector in ECI coordinates.
+            sat: Satellite object.
+            meas_ECI: Target position vector in ECI coordinates.
 
         Returns:
-            Tuple[float, float]: In-track and cross-track angles between satellite and target.
+            In-track and cross-track angles between satellite and target.
         """
         sensor_measurement = self.transform_eci_to_bearings(
             sat.orbit.r.value, sat.orbit.v.value, meas_ECI
@@ -91,7 +109,9 @@ class sensor:
 
         return float(sensor_measurement[0]), float(sensor_measurement[1])
 
-    def transform_eci_to_bearings(self, r_value, v_value, meas_ECI):
+    def transform_eci_to_bearings(
+        self, r_value: jnpt.ArrayLike, v_value: jnpt.ArrayLike, meas_ECI: jnpt.ArrayLike
+    ) -> jnpt.ArrayLike:
         """
         Transform ECI coordinates to bearings angles.
 
@@ -170,17 +190,19 @@ class sensor:
         # Return the relative bearings from sensor to target
         return jnp.array([in_track_angle_deg, cross_track_angle_deg])
 
-    def jacobian_ECI_to_bearings(self, sat, meas_ECI_full):
+    def jacobian_ECI_to_bearings(
+        self, sat: satelliteClass.Satellite, meas_ECI_full: npt.NDArray
+    ) -> npt.NDArray:
         """
         Compute the Jacobian matrix H used in a Kalman filter for the sensor. Describes
         sensitivity of the sensor measurements to changes in predicted state of the target.
 
         Args:
-            sat (Satellite): Satellite object.
-            meas_ECI_full (np.ndarray): Full ECI measurement vector [x, vx, y, vy, z, vz].
+            sat: Satellite object.
+            meas_ECI_full: Full ECI measurement vector [x, vx, y, vy, z, vz].
 
         Returns:
-            np.ndarray: Jacobian matrix H.
+            Jacobian matrix H.
         """
         # Extract predited position from the full ECI measurement vector
         pred_position = jnp.array(
@@ -203,16 +225,16 @@ class sensor:
 
         return new_jacobian
 
-    def inFOV(self, sat, targ):
+    def inFOV(self, sat: satelliteClass.Satellite, targ: targetClass.Target) -> bool:
         """
         Check if the target is within the satellite's field of view (FOV).
 
         Parameters:
-            sat (Satellite): The satellite object.
-            targ (Target): The target object.
+            sat: The satellite object.
+            targ: The target object.
 
         Returns:
-            bool: True if the target is within the FOV, False otherwise.
+            True if the target is within the FOV, False otherwise.
         """
         # Get the target position
         l0 = targ.pos
@@ -241,7 +263,7 @@ class sensor:
             # Target is outside the FOV
             return False
 
-    def visible_projection(self, sat):
+    def visible_projection(self, sat: satelliteClass.Satellite) -> None:
         """
         Compute the projection box of the sensor based on satellite position and FOV.
 
@@ -268,16 +290,16 @@ class sensor:
         self.projBox = np.array(points)  # update the projection box
         return
 
-    def projection_vectors(self, sat):
+    def projection_vectors(self, sat: satelliteClass.Satellite) -> npt.NDArray:
         """
         Compute the direction vectors that define the projection box based on FOV and satellite position.
         Each direction vector is 45 degrees diagonally from radial vector forming a polygon.
 
         Args:
-            sat (Satellite): Satellite object.
+            sat: Satellite object.
 
         Returns:
-            np.ndarray: Array containing four direction vectors of the projection box that define a polygon.
+            Array containing four direction vectors of the projection box that define a polygon.
         """
         # Get the current xyz position of the satellite
         sat_pos = sat.orbit.r.value
@@ -338,8 +360,12 @@ class sensor:
         return np.array(dir_new_list)
 
     def sphere_line_intersection(
-        self, sphere_center, sphere_radius, line_point, line_direction
-    ):
+        self,
+        sphere_center: tuple[float, float, float],
+        sphere_radius: float,
+        line_point: tuple[float, float, float],
+        line_direction: tuple[float, float, float],
+    ) -> npt.NDArray | None:
         """
         Calculate the intersection point of a projection vector with a sphere. Used to find the
         the point where the satellite projection vector intersects with the Earth to define a
@@ -352,7 +378,7 @@ class sensor:
             line_direction (tuple): The (dx, dy, dz) direction vector of the line.
 
         Returns:
-            np.ndarray: The intersection point, or None if there is no intersection.
+            The intersection point, or None if there is no intersection.
         """
         # Unpack sphere parameters
         x0, y0, z0 = sphere_center
@@ -394,7 +420,7 @@ class sensor:
             else:
                 return intersection_point2
 
-    def normalize(self, vec):
+    def normalize(self, vec: jnpt.ArrayLike) -> jnpt.ArrayLike:
         """
         Normalize a vector.
 

--- a/phase3/targetClass.py
+++ b/phase3/targetClass.py
@@ -1,32 +1,33 @@
 from import_libraries import *
+from numpy import typing as npt
 
 
-class target:
+class Target:
     def __init__(
         self,
-        name,
-        targetID,
-        coords,
-        heading,
-        speed,
-        color,
-        uncertainty=np.array([0, 0, 0, 0, 0]),
-        climbrate=0,
-        changeAoA=False,
-        tqReq=0,
+        name: str,
+        targetID: int,
+        coords: npt.NDArray,
+        heading: float,
+        speed: float,
+        color: str,
+        uncertainty: npt.NDArray = np.array([0, 0, 0, 0, 0]),
+        climbrate: float = 0,
+        changeAoA: bool = False,
+        tqReq: int = 0,
     ):
         """Target class that moves linearly around the earth with constant angular velocity.
 
         Args:
-            name (str): Name of the target.
-            targetID (int): ID of the target.
-            coords (np.array): Initial position [latitude, longitude, altitude].
-            heading (float): Heading direction in degrees.
-            speed (float): Speed in km/h.
-            uncertainty (np.array): Uncertainty in the coordinates, heading, and speed of the target. [lat (deg), lon (deg), alt (km), heading (deg), speed (km/min)]
-            color (str): Color representation of the target.
-            climbrate (float): Climbing rate in km/h. Defaults to 0.
-            changeAoA (bool): Whether the target should change Angle of Attack. Defaults to False.
+            name: Name of the target.
+            targetID: ID of the target.
+            coords: Initial position [latitude, longitude, altitude].
+            heading: Heading direction in degrees.
+            speed: Speed in km/h.
+            uncertainty: Uncertainty in the coordinates, heading, and speed of the target. [lat (deg), lon (deg), alt (km), heading (deg), speed (km/min)]
+            color: Color representation of the target.
+            climbrate: Climbing rate in km/h. Defaults to 0.
+            changeAoA: Whether the target should change Angle of Attack. Defaults to False.
         """
 
         # Initialize the target's parameters
@@ -77,7 +78,9 @@ class target:
             dict
         )  # Contains time, xyz, and velocity history in ECI [x xdot y ydot z zdot]
 
-    def propagate(self, time_step, time, initialState=None):
+    def propagate(
+        self, time_step: float, time: float, initialState: npt.NDArray | None = None
+    ) -> None:
         """Linearly propagate target state in spherical coordinates then transform back to ECI.
 
         Args:


### PR DESCRIPTION
Add Python type annotations to the code. I made it about ~50% of the way through so far.

I generally stuck with annotating the functions as they were declared to be, although this PR has a few deviations:
- I renamed classes to be title case (it was bugging me)
- I ignored typing nuance between `npt.NDArray` and `jnpt.ArrayLike` and left the conversion errors between the two for now
- I ignored type errors that popped up in my editor (many, many of them)
- Most `optional X` annotations in the docstring were wrong (not `X | None`, just meant "has a default")
- I stuck simplified `float | int` annotations to just `float`
  - I haven't checked for `isinstance` calls that would be prone to failure here

Everything else is just type annotations with no runtime implications