### PR TITLE
Remove `NestedDict`, replace with flat dataclasses

### DIFF
--- a/common/dataclassframe.py
+++ b/common/dataclassframe.py
@@ -1,0 +1,38 @@
+import dataclasses
+from typing import ClassVar, Generic, Protocol, Type, TypeVar
+
+import pandas as pd
+
+
+class DataclassLike(Protocol):
+    __dataclass_fields__: ClassVar[dict[str, dataclasses.Field]]
+
+
+T = TypeVar('T', bound=DataclassLike)
+
+
+class DataClassFrame(pd.DataFrame, Generic[T]):
+    """A DataFrame with wrappers to insert and extract dataclasses."""
+
+    # Pandas overrides so we can set `self._clz`
+    _internal_names = pd.DataFrame._internal_names + ['_clz']  # type: ignore
+    _internal_names_set = set(_internal_names)
+
+    def __init__(self, data: list[T] | None = None, *args, clz: Type[T], **kwargs):
+        self._clz = clz
+        if 'columns' in kwargs:
+            raise ValueError('columns must not be provided')
+        data_dicts = [dataclasses.asdict(d) for d in data] if data else None
+        kwargs['columns'] = [f.name for f in dataclasses.fields(clz)]
+        super().__init__(data_dicts, *args, **kwargs)  # type: ignore
+
+    def __new__(cls, *args, **kwargs):
+        return super().__new__(cls)
+
+    def append(self, data: T) -> None:
+        self.loc[len(self)] = dataclasses.asdict(data)  # type: ignore
+
+    def to_dataclasses(self, other: pd.DataFrame | None = None) -> list[T]:
+        if other is None:
+            other = self
+        return other.apply(lambda row: self._clz(*row), axis=1).tolist()  # type: ignore

--- a/common/dataclassframe_test.py
+++ b/common/dataclassframe_test.py
@@ -1,0 +1,53 @@
+import dataclasses
+import unittest
+
+from common import dataclassframe
+
+
+@dataclasses.dataclass
+class TestClass:
+    a: int
+    b: str
+
+
+class TestDataClassFrame(unittest.TestCase):
+    def test_insert_data(self):
+        frame = dataclassframe.DataClassFrame(clz=TestClass)
+
+        frame.append(TestClass(1, 'a'))
+        frame.append(TestClass(2, 'b'))
+
+        self.assertEqual(len(frame), 2)
+        self.assertEqual(frame['a'].tolist(), [1, 2])
+        self.assertEqual(frame['b'].tolist(), ['a', 'b'])
+
+    def test_to_dataclasses(self):
+        data = [
+            TestClass(1, 'a'),
+            TestClass(2, 'b'),
+        ]
+        frame = dataclassframe.DataClassFrame(data, clz=TestClass)
+
+        data = frame.to_dataclasses()
+
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0], TestClass(1, 'a'))
+        self.assertEqual(data[1], TestClass(2, 'b'))
+
+    def test_operated_on(self):
+        data = [
+            TestClass(1, 'a'),
+            TestClass(2, 'b'),
+        ]
+        frame = dataclassframe.DataClassFrame(data, clz=TestClass)
+
+        # Operating on the frame will return a regular DataFrame
+        subset = frame[frame['a'] > 1]
+
+        self.assertEqual(subset['a'].tolist(), [2])
+        # But our original frame can accept the new frame as an arg
+        self.assertEqual(frame.to_dataclasses(subset), [TestClass(2, 'b')])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/phase3/collection.py
+++ b/phase3/collection.py
@@ -1,0 +1,81 @@
+"""Interfaces & utilities for collected data from the simulation."""
+
+import dataclasses
+from collections import defaultdict
+from typing import Sequence
+
+from numpy import typing as npt
+
+TargetAggregator = dict[int, dict[str, int]]
+
+
+@dataclasses.dataclass
+class Transmission:
+    target_id: int
+    sender: str
+    receiver: str
+    time: float
+    size: int
+
+
+@dataclasses.dataclass
+class ArrayTransmission(Transmission):
+    data: npt.NDArray | None
+
+
+def aggregate_transmissions(
+    transmissions: Sequence[Transmission], sat_names: list[str]
+) -> tuple[dict[str, int], TargetAggregator, TargetAggregator]:
+    """Aggregate the transmissions by target ID and satellite name.
+
+    Args:
+        transmissions: List of transmissions to aggregate.
+        sat_names: List of satellite names.
+
+    Returns:
+        Aggregated transmissions of `prev_data`, `target_sent_data`, and `target_rec_data`.
+    """
+
+    # Save previous data, to stack the bars
+    # prev_data = np.zeros(len(satNames))
+    # make prev_data a dictionary
+    prev_data = {sat: 0 for sat in sat_names}
+
+    # Per-target transmissions
+    target_sent_data: dict[int, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    target_rec_data: dict[int, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    for transmission in transmissions:
+        target_sent_data[transmission.target_id][
+            transmission.sender
+        ] += transmission.size
+        target_rec_data[transmission.target_id][
+            transmission.receiver
+        ] += transmission.size
+
+    # Ensure parity between sent and received data keys
+    for target_id in target_sent_data.keys() | target_rec_data.keys():
+        for sat in target_sent_data[target_id]:
+            target_rec_data[target_id][sat] += 0
+        for sat in target_rec_data[target_id]:
+            target_sent_data[target_id][sat] += 0
+
+        # Order the data the same way, according to "sats" variable
+        target_sent_data[target_id] = dict(
+            sorted(
+                target_sent_data[target_id].items(),
+                key=lambda item: sat_names.index(item[0]),
+            )
+        )
+        target_rec_data[target_id] = dict(
+            sorted(
+                target_rec_data[target_id].items(),
+                key=lambda item: sat_names.index(item[0]),
+            )
+        )
+
+        # Add the rec_data values to the prev_data
+        for sat in target_rec_data[target_id].keys():
+            prev_data[sat] += target_rec_data[target_id][sat]
+
+    return prev_data, target_sent_data, target_rec_data

--- a/phase3/collection.py
+++ b/phase3/collection.py
@@ -1,12 +1,19 @@
 """Interfaces & utilities for collected data from the simulation."""
 
 import dataclasses
+import enum
 from collections import defaultdict
 from typing import Sequence
 
+import numpy as np
 from numpy import typing as npt
 
 TargetAggregator = dict[int, dict[str, int]]
+
+
+class GsDataType(enum.Enum):
+    CI = enum.auto()
+    MEAS = enum.auto()
 
 
 @dataclasses.dataclass
@@ -19,8 +26,34 @@ class Transmission:
 
 
 @dataclasses.dataclass
-class ArrayTransmission(Transmission):
-    data: npt.NDArray | None
+class MeasurementTransmission(Transmission):
+    alpha: float
+    beta: float
+
+    @property
+    def has_alpha_beta(self) -> bool:
+        return not np.isnan(self.alpha) and not np.isnan(self.beta)
+
+
+@dataclasses.dataclass
+class GsTransmission:
+    target_id: int
+    # Sending satellite
+    sender: str
+    # Receiving ground station
+    receiver: str
+    time: float
+
+
+@dataclasses.dataclass
+class GsEstimateTransmission(GsTransmission):
+    estimate: npt.NDArray
+    covariance: npt.NDArray
+
+
+@dataclasses.dataclass
+class GsMeasurementTransmission(GsTransmission):
+    measurement: npt.NDArray | None
 
 
 def aggregate_transmissions(

--- a/phase3/comms.py
+++ b/phase3/comms.py
@@ -5,6 +5,7 @@ import numpy as np
 from astropy import units as u
 from numpy import typing as npt
 
+from common import dataclassframe
 from phase3 import collection
 from phase3 import satellite
 
@@ -38,11 +39,17 @@ class Comms:
         self.maxBandwidth = maxBandwidth
 
         # Create a empty dicitonary to store the amount of data sent/recieved between satellites
-        self.total_comm_data: list[collection.Transmission] = []
-        self.used_comm_data: list[collection.Transmission] = []
+        self.total_comm_data = dataclassframe.DataClassFrame(
+            clz=collection.Transmission
+        )
+        self.used_comm_data = dataclassframe.DataClassFrame(clz=collection.Transmission)
 
-        self.total_comm_et_data: list[collection.ArrayTransmission] = []
-        self.used_comm_et_data: list[collection.ArrayTransmission] = []
+        self.total_comm_et_data = dataclassframe.DataClassFrame(
+            clz=collection.MeasurementTransmission
+        )
+        self.used_comm_et_data = dataclassframe.DataClassFrame(
+            clz=collection.MeasurementTransmission
+        )
 
         self.max_neighbors = maxNeighbors
         self.max_range = maxRange
@@ -164,7 +171,8 @@ class Comms:
         self,
         sender: satellite.Satellite,
         receiver: satellite.Satellite,
-        meas_vector: npt.NDArray,
+        alpha: float,
+        beta: float,
         target_id: int,
         time: float,
     ) -> None:
@@ -181,7 +189,8 @@ class Comms:
         Args:
             sender: Satellite sending the measurements.
             receiver: Satellite receiving the measurements.
-            meas_vector: Measurement vector to send.
+            alpha: Alpha measurement to send.
+            beta: Beta measurement to send.
             target_id: ID of the target the measurements are from.
             time: Time the measurements were taken.
         """
@@ -202,7 +211,7 @@ class Comms:
 
         # Add the measurement vector to the receiver's measurement data at the specified target_id and time
         self.G.nodes[receiver]['received_measurements'][time][target_id]['meas'].append(
-            meas_vector
+            (alpha, beta)
         )
         self.G.nodes[receiver]['received_measurements'][time][target_id][
             'sender'
@@ -219,31 +228,32 @@ class Comms:
             }
 
         self.G.nodes[sender]['sent_measurements'][time][target_id]['meas'].append(
-            meas_vector
+            (alpha, beta)
         )
         self.G.nodes[sender]['sent_measurements'][time][target_id]['receiver'].append(
             receiver
         )
 
         measVector_size = 2 + 2  # 2 for the meas vector, 2 for the sensor noise
-        if np.isnan(meas_vector[0]):
+        if np.isnan(alpha):
             measVector_size -= 1
 
-        if np.isnan(meas_vector[1]):
+        if np.isnan(beta):
             measVector_size -= 1
 
         self.total_comm_et_data.append(
-            collection.ArrayTransmission(
+            collection.MeasurementTransmission(
                 target_id=target_id,
                 sender=sender.name,
                 receiver=receiver.name,
                 time=time,
                 size=measVector_size,
-                data=meas_vector,
+                alpha=alpha,
+                beta=beta,
             )
         )
 
-    # self.total_comm_data[target_id][receiver.name][sender.name][time] = meas_vector.size # TODO: need a new dicitonary to store this and sent data
+        # self.total_comm_data[target_id][receiver.name][sender.name][time] = meas_vector.size # TODO: need a new dicitonary to store this and sent data
 
     def update_edges(self) -> None:
         """Reset the edges in the graph and redefine them based on range and if the Earth is blocking them.

--- a/phase3/environment.py
+++ b/phase3/environment.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import random
 from collections import defaultdict
+from typing import cast
 
 import imageio
 import networkx as nx
@@ -15,9 +16,11 @@ from matplotlib import gridspec
 from matplotlib import patches
 from matplotlib import pyplot as plt
 from mpl_toolkits.mplot3d import art3d
+from mpl_toolkits.mplot3d import axes3d
 from numpy import typing as npt
 
 from common import path_utils
+from phase3 import collection
 from phase3 import comms
 from phase3 import estimator
 from phase3 import groundStation
@@ -27,6 +30,7 @@ from phase3 import sensor
 from phase3 import sim_config
 from phase3 import target
 from phase3 import util
+from phase3.plotting import comms as comms_plot
 
 ## Creates the environment class, which contains a vector of satellites all other parameters
 
@@ -91,17 +95,13 @@ class Environment:
 
         self.groundStations = groundStations  # define the ground stations
 
-        # Define variables to track the comms
-        self.comms.total_comm_data = util.NestedDict()
-        self.used_comm_data = util.NestedDict()
-
         # Initialize time parameter to 0
-        self.time: u.Quantity[u.minute] = 0 * u.minute
+        self.time = u.Quantity(0, u.minute)
         self.delta_t = None
 
         # Environemnt Plotting parameters
         self.fig = plt.figure(figsize=(10, 8))
-        self.ax = self.fig.add_subplot(111, projection='3d')
+        self.ax = cast(axes3d.Axes3D, self.fig.add_subplot(111, projection='3d'))
 
         # If you want to do clustered case:
         self.ax.set_xlim([2000, 8000])
@@ -140,7 +140,7 @@ class Environment:
 
     def simulate(
         self,
-        time_vec: npt.NDArray,
+        time_vec: u.Quantity,
         plot_config: sim_config.PlotConfig,
         pause_step: float = 0.0001,
         save_estimation_data: bool = False,
@@ -164,7 +164,7 @@ class Environment:
 
         # Initialize based on the current time
         time_vec = time_vec + self.time
-        self.delta_t = (time_vec[1] - time_vec[0]).to_value(time_vec.unit)
+        self.delta_t = (time_vec[1] - time_vec[0]).value
         for t_net in time_vec:
 
             print(f"Time: {t_net:.2f}")
@@ -181,7 +181,7 @@ class Environment:
                     sat.targPriority = self.commandersIntent[
                         t_net.to_value(t_net.unit)
                     ][sat.name]
-                    sat.targetIDs = sat.targPriority.keys()
+                    sat.targetIDs = list(sat.targPriority.keys())
 
             # Collect individual data measurements for satellites and then do data fusion
             self.data_fusion()
@@ -642,7 +642,7 @@ class Environment:
             ) in self.targs:  # TODO: iniitalize with senders est and cov + noise?
                 if target.targetID in sat.targetIDs:
                     targetID = target.targetID
-                    envTime = self.time.to_value()
+                    envTime = self.time.value
                     # Skip if there are no measurements for this targetID
                     if isinstance(
                         sat.measurementHist[target.targetID][envTime], np.ndarray
@@ -720,11 +720,17 @@ class Environment:
                             )
 
                             if commonEKF.synchronizeFlag[targetID][envTime]:
-                                self.comms.total_comm_et_data[targetID][sat.name][
-                                    neighbor.name
-                                ][
-                                    envTime
-                                ] = 50  # since this runs twice, we need to make sure we don't double count the data
+                                # Since this runs twice, we need to make sure we don't double count the data
+                                self.comms.total_comm_et_data.append(
+                                    collection.ArrayTransmission(
+                                        target_id=targetID,
+                                        sender=sat.name,
+                                        receiver=neighbor.name,
+                                        time=envTime,
+                                        size=50,
+                                        data=None,
+                                    )
+                                )
 
     def central_fusion(self, collectedFlag, measurements):
         """
@@ -1819,7 +1825,14 @@ class Environment:
                         linewidth=linewidth,
                     )
 
-    def plot_et_messages(self, ax, sat, sat2, targetID, timeVec):
+    def plot_et_messages(
+        self,
+        ax,
+        sat: satellite.Satellite,
+        sat2: satellite.Satellite,
+        targetID: int,
+        timeVec,
+    ):
         # TODO: EITHER USE THIS OR DONT USE THIS!, SHOWS THE ET MESSAGING
 
         # Find common EKF
@@ -1835,15 +1848,17 @@ class Environment:
                     ax.scatter(time, 0.5, color='g', marker='D', s=70)
                     continue
 
-            if isinstance(
-                self.comms.used_comm_et_data_values[targetID][sat.name][sat2.name][
-                    time
-                ],
-                np.ndarray,
-            ):
-                alpha, beta = self.comms.used_comm_et_data_values[targetID][sat.name][
-                    sat2.name
-                ][time]
+            related_comms = list(
+                filter(
+                    lambda x: x.sender == sat.name
+                    and x.receiver == sat2.name
+                    and x.target_id == targetID
+                    and x.time == time,
+                    self.comms.used_comm_et_data,
+                )
+            )
+            if len(related_comms) > 0 and related_comms[0].data is not None:
+                alpha, beta = related_comms[0].data
                 if not np.isnan(alpha):
                     ax.scatter(time, 0.9, color='r', marker=r'$\alpha$', s=80)
                 else:
@@ -2063,563 +2078,76 @@ class Environment:
 
     ### Plot communications sent/recieved
     # Plot the total data sent and received by satellites
-    def plot_global_comms(self, saveName):
-        """PLOTS THE TOTAL DATA SEND AND RECEIVED BY SATELLITES IN DDF ALGORITHMS"""
+    def plot_global_comms(self, saveName: str | None):
+        """Plots the total data sent and received by satellites in DDF algorithms"""
+        # Get the names of satellites:
+        sat_names = [sat.name for sat in self.sats]
 
         ## Plot comm data sent for CI Algo
         if self.estimator_config.ci:
-
-            # Create a figure
-            fig = plt.figure(figsize=(15, 8))
-            fig.suptitle(f"TOTAL Data Sent and Received by Satellites", fontsize=14)
-            ax = fig.add_subplot(111)
-
-            # Get the names of satellites:
-            satNames = [sat.name for sat in self.sats]
-
-            # Save previous data, to stack the bars
-            # prev_data = np.zeros(len(satNames))
-            # make prev_data a dictionary
-            prev_data = {sat: 0 for sat in satNames}
-
-            # Loop through all targets, in order listed in the environment
-            # for target_id in self.comms.total_comm_data:
-            count = 0
-            for targ in self.targs:
-
-                sent_data = defaultdict(dict)
-                rec_data = defaultdict(dict)
-
-                # Get the color for the target:
-                color = targ.color
-
-                # Get the target id
-                target_id = targ.targetID
-
-                # Now check, does that target have any communication data
-                if target_id not in self.comms.total_comm_data:
-                    continue
-
-                count += 1
-
-                for reciever in self.comms.total_comm_data[target_id]:
-
-                    for sender in self.comms.total_comm_data[target_id][reciever]:
-                        if sender == reciever:
-                            continue
-
-                        # Goal is to count the amoutn of data reciever has receieved as well as sender has sent
-
-                        for time in self.comms.total_comm_data[target_id][reciever][
-                            sender
-                        ]:
-
-                            # Get the data
-                            data = self.comms.total_comm_data[target_id][reciever][
-                                sender
-                            ][time]
-
-                            # Count the amount of data receiver by the receiver
-                            if reciever not in rec_data:
-                                rec_data[reciever] = 0
-                            rec_data[reciever] += data
-
-                            # Count the amount of data sent by the sender
-                            if sender not in sent_data:
-                                sent_data[sender] = 0
-                            sent_data[sender] += data
-
-                # If there are keys that dont exist in sent_data, make them and their value 0
-                for key in prev_data.keys():
-                    if key not in sent_data:
-                        sent_data[key] = 0
-                    if key not in rec_data:
-                        rec_data[key] = 0
-
-                # Order the data the same way, according to "sats" variable
-                sent_data = dict(
-                    sorted(sent_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-                rec_data = dict(
-                    sorted(rec_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-
-                p1 = ax.bar(
-                    list(sent_data.keys()),
-                    list(sent_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                )
-
-                # Add text labels to show which target is which.
-                for i, v in enumerate(list(sent_data.values())):
-                    ax.text(
-                        i,
-                        list(prev_data.values())[i],
-                        targ.name,
-                        ha='center',
-                        va='bottom',
-                        color='black',
-                    )
-
-                # Add the sent_data values to the prev_data
-                for key in sent_data.keys():
-                    prev_data[key] += sent_data[key]
-
-                p2 = ax.bar(
-                    list(rec_data.keys()),
-                    list(rec_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                    fill=False,
-                    hatch='//',
-                    edgecolor=color,
-                )
-
-                # Add the rec_data values to the prev_data
-                for key in rec_data.keys():
-                    prev_data[key] += rec_data[key]
-
-                if count == 1:
-                    # Add legend
-                    ax.legend((p1[0], p2[0]), ('Sent Data', 'Received Data'))
-
-            # Add the labels
-            ax.set_ylabel('Total Data Sent/Recieved (# of numbers)')
-
-            # Add the x-axis labels
-            ax.set_xticks(np.arange(len(satNames)))
-            ax.set_xticklabels(satNames)
-
-            # Now save the plot
-            if saveName is not None:
-                filePath = os.path.dirname(os.path.realpath(__file__))
-                plotPath = os.path.join(filePath, 'plots')
-                os.makedirs(plotPath, exist_ok=True)
-                plt.savefig(
-                    os.path.join(plotPath, f"{saveName}_total_ci_comms.png"), dpi=300
-                )
-            else:
-                filePath = os.path.dirname(os.path.realpath(__file__))
-                plotPath = os.path.join(filePath, 'plots')
-                plt.savefig(os.path.join(plotPath, f"total_ci_comms.png"), dpi=300)
+            comms_plot.create_comms_plot(
+                self.comms.total_comm_data,
+                self.targs,
+                sat_names,
+                super_title='TOTAL Data Sent and Received by Satellites',
+                y_label='Total Data Sent/Recieved (# of numbers)',
+                filename='total_ci_comms',
+                prefix=saveName,
+                save=True,
+            )
 
         ## Plot comm data sent for ET Algo
         if self.estimator_config.et:
-
-            fig = plt.figure(figsize=(15, 8))
-            fig.suptitle(f"ET Data Sent and Received by Satellites", fontsize=14)
-
-            ax = fig.add_subplot(111)
-
-            # Get the names of satellites:
-            satNames = [sat.name for sat in self.sats]
-
-            # Save previous data, to stack the bars
-            prev_data = {sat: 0 for sat in satNames}
-
-            # Loop through all targets, in order listed in the environment
-            count = 0
-            for targ in self.targs:
-
-                sent_data = defaultdict(dict)
-                rec_data = defaultdict(dict)
-
-                # Get the color for the target:
-                color = targ.color
-
-                # Get the target id
-                target_id = targ.targetID
-
-                # Now check, does that target have any communication data
-                if target_id not in self.comms.total_comm_et_data:
-                    continue
-
-                count += 1
-
-                for reciever in self.comms.total_comm_et_data[target_id]:
-
-                    for sender in self.comms.total_comm_et_data[target_id][reciever]:
-                        if sender == reciever:
-                            continue
-
-                        # Goal is to count the amoutn of data reciever has receieved as well as sender has sent
-
-                        for time in self.comms.total_comm_et_data[target_id][reciever][
-                            sender
-                        ]:
-
-                            # Get the data
-                            data = self.comms.total_comm_et_data[target_id][reciever][
-                                sender
-                            ][time]
-
-                            # Count the amount of data receiver by the receiver
-                            if reciever not in rec_data:
-                                rec_data[reciever] = 0
-                            rec_data[reciever] += data
-
-                            # Count the amount of data sent by the sender
-                            if sender not in sent_data:
-                                sent_data[sender] = 0
-                            sent_data[sender] += data
-
-                # If there are keys that dont exist in sent_data, make them and their value 0
-                for key in prev_data.keys():
-                    if key not in sent_data:
-                        sent_data[key] = 0
-                    if key not in rec_data:
-                        rec_data[key] = 0
-
-                # Order the data the same way, according to "sats" variable
-                sent_data = dict(
-                    sorted(sent_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-                rec_data = dict(
-                    sorted(rec_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-
-                p1 = ax.bar(
-                    list(sent_data.keys()),
-                    list(sent_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                )
-
-                # Add text labels to show which target is which.
-                for i, v in enumerate(list(sent_data.values())):
-                    ax.text(
-                        i,
-                        list(prev_data.values())[i],
-                        targ.name,
-                        ha='center',
-                        va='bottom',
-                        color='black',
-                    )
-
-                # Add the sent_data values to the prev_data
-                for key in sent_data.keys():
-                    prev_data[key] += sent_data[key]
-
-                p2 = ax.bar(
-                    list(rec_data.keys()),
-                    list(rec_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                    fill=False,
-                    hatch='//',
-                    edgecolor=color,
-                )
-
-                # Add the rec_data values to the prev_data
-                for key in rec_data.keys():
-                    prev_data[key] += rec_data[key]
-
-                if count == 1:
-                    # Add legend
-                    ax.legend((p1[0], p2[0]), ('Sent Data', 'Received Data'))
-
-            # Add the labels
-            ax.set_ylabel('ET Data Sent/Recieved (# of numbers)')
-
-            # Add the x-axis labels
-            ax.set_xticks(np.arange(len(satNames)))
-            ax.set_xticklabels(satNames)
-
-            # Now save the plot
-            filePath = os.path.dirname(os.path.realpath(__file__))
-            plotPath = os.path.join(filePath, 'plots')
-            os.makedirs(plotPath, exist_ok=True)
-            plt.savefig(
-                os.path.join(plotPath, f"{saveName}_total_et_comms.png"), dpi=300
+            comms_plot.create_comms_plot(
+                self.comms.total_comm_et_data,
+                self.targs,
+                sat_names,
+                super_title='TOTAL ET Data Sent and Received by Satellites',
+                y_label='Total ET Data Sent/Recieved (# of numbers)',
+                filename='total_et_comms',
+                prefix=saveName,
+                save=True,
             )
 
     # Plots the actual data amount used by the satellites
-    # TODO: REMOVE? IT HONESTLY DOESNT MATTER
-    def plot_used_comms(self, saveName):
+    # TODO: Remove? It honestly doesn't matter
+    def plot_used_comms(self, saveName: str | None):
         """
-        PLOTS THE USED DATA SEND AND RECEIVED BY SATELLITES IN DDF ALGORITHMS
+        Plots the used data sent and received by satellites in DDF algorithms.
 
-            Used means information used for a sat to meet TQ requirements
-
+        'Used' means information used for a satellite to meet TQ requirements.
         """
+        sat_names = [sat.name for sat in self.sats]
 
         ## Plot comm data sent for CI Algo
         if self.estimator_config.ci:
-
-            # Create a figure
-            fig = plt.figure(figsize=(15, 8))
-            fig.suptitle(f"USED Data Sent and Received by Satellites", fontsize=14)
-            ax = fig.add_subplot(111)
-
-            # Get the names of satellites:
-            satNames = [sat.name for sat in self.sats]
-
-            # Save previous data, to stack the bars
-            # prev_data = np.zeros(len(satNames))
-            # make prev_data a dictionary
-            prev_data = {sat: 0 for sat in satNames}
-
-            # Loop through all targets, in order listed in the environment
-            # for target_id in self.comms.total_comm_data:
-            count = 0
-            for targ in self.targs:
-
-                sent_data = defaultdict(dict)
-                rec_data = defaultdict(dict)
-
-                # Get the color for the target:
-                color = targ.color
-
-                # Get the target id
-                target_id = targ.targetID
-
-                # Now check, does that target have any communication data
-                if target_id not in self.comms.used_comm_data:
-                    continue
-
-                count += 1
-
-                for reciever in self.comms.used_comm_data[target_id]:
-
-                    for sender in self.comms.used_comm_data[target_id][reciever]:
-                        if sender == reciever:
-                            continue
-
-                        # Goal is to count the amoutn of data reciever has receieved as well as sender has sent
-
-                        for time in self.comms.used_comm_data[target_id][reciever][
-                            sender
-                        ]:
-
-                            # Get the data
-                            data = self.comms.used_comm_data[target_id][reciever][
-                                sender
-                            ][time]
-
-                            # Count the amount of data receiver by the receiver
-                            if reciever not in rec_data:
-                                rec_data[reciever] = 0
-                            rec_data[reciever] += data
-
-                            # Count the amount of data sent by the sender
-                            if sender not in sent_data:
-                                sent_data[sender] = 0
-                            sent_data[sender] += data
-
-                # If there are keys that dont exist in sent_data, make them and their value 0
-                for key in prev_data.keys():
-                    if key not in sent_data:
-                        sent_data[key] = 0
-                    if key not in rec_data:
-                        rec_data[key] = 0
-
-                # Order the data the same way, according to "sats" variable
-                sent_data = dict(
-                    sorted(sent_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-                rec_data = dict(
-                    sorted(rec_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-
-                p1 = ax.bar(
-                    list(sent_data.keys()),
-                    list(sent_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                )
-
-                # Add text labels to show which target is which.
-                for i, v in enumerate(list(sent_data.values())):
-                    ax.text(
-                        i,
-                        list(prev_data.values())[i],
-                        targ.name,
-                        ha='center',
-                        va='bottom',
-                        color='black',
-                    )
-
-                # Add the sent_data values to the prev_data
-                for key in sent_data.keys():
-                    prev_data[key] += sent_data[key]
-
-                p2 = ax.bar(
-                    list(rec_data.keys()),
-                    list(rec_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                    fill=False,
-                    hatch='//',
-                    edgecolor=color,
-                )
-
-                # Add the rec_data values to the prev_data
-                for key in rec_data.keys():
-                    prev_data[key] += rec_data[key]
-
-                if count == 1:
-                    # Add legend
-                    ax.legend((p1[0], p2[0]), ('Sent Data', 'Received Data'))
-
-            # Add the labels
-            ax.set_ylabel('Used Data Sent/Recieved (# of numbers)')
-
-            # Add the x-axis labels
-            ax.set_xticks(np.arange(len(satNames)))
-            ax.set_xticklabels(satNames)
-
-            # Now save the plot
-            if saveName is not None:
-                filePath = os.path.dirname(os.path.realpath(__file__))
-                plotPath = os.path.join(filePath, 'plots')
-                os.makedirs(plotPath, exist_ok=True)
-                plt.savefig(
-                    os.path.join(plotPath, f"{saveName}_used_ci_comms.png"), dpi=300
-                )
-            else:
-                filePath = os.path.dirname(os.path.realpath(__file__))
-                plotPath = os.path.join(filePath, 'plots')
-                plt.savefig(os.path.join(plotPath, f"used_ci_comms.png"), dpi=300)
+            comms_plot.create_comms_plot(
+                self.comms.used_comm_data,
+                self.targs,
+                sat_names,
+                super_title='USED Data Sent and Received by Satellites',
+                y_label='Used Data Sent/Recieved (# of numbers)',
+                filename='used_ci_comms',
+                prefix=saveName,
+                save=True,
+            )
 
         ## Plot comm data sent for ET Algo
         if self.estimator_config.et:
-
-            # DO the exact same thing for ET data
-            # Create a figure
-            fig = plt.figure(figsize=(15, 8))
-            fig.suptitle(f"USED ET Data Sent and Received by Satellites", fontsize=14)
-            ax = fig.add_subplot(111)
-
-            # Get the names of satellites:
-            satNames = [sat.name for sat in self.sats]
-
-            # Save previous data, to stack the bars
-            # prev_data = np.zeros(len(satNames))
-            # make prev_data a dictionary
-            prev_data = {sat: 0 for sat in satNames}
-
-            # Loop through all targets, in order listed in the environment
-            # for target_id in self.comms.total_comm_data:
-            count = 0
-            for targ in self.targs:
-
-                sent_data = defaultdict(dict)
-                rec_data = defaultdict(dict)
-
-                # Get the color for the target:
-                color = targ.color
-
-                # Get the target id
-                target_id = targ.targetID
-
-                # Now check, does that target have any communication data
-                if target_id not in self.comms.used_comm_et_data:
-                    continue
-
-                count += 1
-
-                for reciever in self.comms.used_comm_et_data[target_id]:
-
-                    for sender in self.comms.used_comm_et_data[target_id][reciever]:
-                        if sender == reciever:
-                            continue
-
-                        # Goal is to count the amoutn of data reciever has receieved as well as sender has sent
-
-                        for time in self.comms.used_comm_et_data[target_id][reciever][
-                            sender
-                        ]:
-
-                            # Get the data
-                            data = self.comms.used_comm_et_data[target_id][reciever][
-                                sender
-                            ][time]
-
-                            # Count the amount of data receiver by the receiver
-                            if reciever not in rec_data:
-                                rec_data[reciever] = 0
-                            rec_data[reciever] += data
-
-                            # Count the amount of data sent by the sender
-                            if sender not in sent_data:
-                                sent_data[sender] = 0
-                            sent_data[sender] += data
-
-                # If there are keys that dont exist in sent_data, make them and their value 0
-                for key in prev_data.keys():
-                    if key not in sent_data:
-                        sent_data[key] = 0
-                    if key not in rec_data:
-                        rec_data[key] = 0
-
-                # Order the data the same way, according to "sats" variable
-                sent_data = dict(
-                    sorted(sent_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-                rec_data = dict(
-                    sorted(rec_data.items(), key=lambda item: satNames.index(item[0]))
-                )
-
-                p1 = ax.bar(
-                    list(sent_data.keys()),
-                    list(sent_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                )
-
-                # Add text labels to show which target is which.
-                for i, v in enumerate(list(sent_data.values())):
-                    ax.text(
-                        i,
-                        list(prev_data.values())[i],
-                        targ.name,
-                        ha='center',
-                        va='bottom',
-                        color='black',
-                    )
-
-                # Add the sent_data values to the prev_data
-                for key in sent_data.keys():
-                    prev_data[key] += sent_data[key]
-
-                p2 = ax.bar(
-                    list(rec_data.keys()),
-                    list(rec_data.values()),
-                    bottom=list(prev_data.values()),
-                    color=color,
-                    fill=False,
-                    hatch='//',
-                    edgecolor=color,
-                )
-
-                # Add the rec_data values to the prev_data
-                for key in rec_data.keys():
-                    prev_data[key] += rec_data[key]
-
-                if count == 1:
-                    # Add legend
-                    ax.legend((p1[0], p2[0]), ('Sent Data', 'Received Data'))
-
-            # Add the labels
-            ax.set_ylabel('Used Data Sent/Recieved (# of numbers)')
-
-            # Add the x-axis labels
-            ax.set_xticks(np.arange(len(satNames)))
-            ax.set_xticklabels(satNames)
-
-            # Now save the plot
-            if saveName is not None:
-                filePath = os.path.dirname(os.path.realpath(__file__))
-                plotPath = os.path.join(filePath, 'plots')
-                os.makedirs(plotPath, exist_ok=True)
-                plt.savefig(
-                    os.path.join(plotPath, f"{saveName}_used_et_comms.png"), dpi=300
-                )
+            comms_plot.create_comms_plot(
+                self.comms.used_comm_et_data,
+                self.targs,
+                sat_names,
+                super_title='USED ET Data Sent and Received by Satellites',
+                y_label='Used ET Data Sent/Recieved (# of numbers)',
+                filename='used_et_comms',
+                prefix=saveName,
+                save=True,
+            )
 
     # Sub plots for each satellite showing the track uncertainty for each target and then the comms sent/recieved about each target vs time
     def plot_timeHist_comms_ci(self, saveName):
-        """PLOTS A TIME HISTORY OF THE CI COMMS RECIEVED FOR EACH SATELLITE ON EVERY TARGET"""
+        """Plots a time history of the CI communications received for each satellite on every target."""
 
         # For each satellite make a plot:
         for sat in self.sats:
@@ -2742,7 +2270,7 @@ class Environment:
             nonEmptyTime.sort()
 
             # also now use a specified order of sats
-            satNames = [sat.name for sat in self.sats]
+            sat_names = [sat.name for sat in self.sats]
 
             # Use the nonEmptyTime to get the minimum difference between time steps
             differences = [j - i for i, j in zip(nonEmptyTime[:-1], nonEmptyTime[1:])]
@@ -2757,17 +2285,34 @@ class Environment:
                     continue
 
                 # Check if the target has any communication data
-                if targ.targetID not in self.comms.used_comm_data:
+                related_comms = list(
+                    filter(
+                        lambda x: x.target_id == targ.targetID,
+                        self.comms.used_comm_data,
+                    )
+                )
+                if not len(related_comms):
                     continue
 
-                for sender in satNames:
+                for sender in sat_names:
                     if sender == sat:
                         continue
 
                     # So now, we have a satellite, the reciever, recieving information about targetID from sender
                     # We want to count, how much information did the reciever recieve from the sender in a time history and plot that on a bar chart
-
-                    data = self.comms.used_comm_data[targ.targetID][sat.name][sender]
+                    related_comms = list(
+                        filter(
+                            lambda x: x.sender == sender
+                            and x.receiver == sat.name
+                            and x.target_id == targ.targetID,
+                            self.comms.used_comm_data,
+                        )
+                    )
+                    data = {
+                        comm.time: comm.size
+                        for comm in related_comms
+                        if comm.time in nonEmptyTime
+                    }
 
                     # Check, does any of the data contain [] or None? If so, make it a 0
                     for key in data:
@@ -2863,12 +2408,16 @@ class Environment:
                             edge_styles.append((sat2, sat, style, targ_color))
 
                         # If there is a communication between the two satellites, add an edge
-                        if isinstance(
-                            comms.total_comm_et_data_values[targ.targetID][sat.name][
-                                sat2.name
-                            ][envTime],
-                            np.ndarray,
-                        ):
+                        related_comms = list(
+                            filter(
+                                lambda x: x.sender == sat.name
+                                and x.receiver == sat2.name
+                                and x.target_id == targetID
+                                and x.time == envTime,
+                                comms.total_comm_et_data,
+                            )
+                        )
+                        if len(related_comms) and related_comms[0].data is not None:
                             diComms.add_edge(sat2, sat)
                             style = self.get_edge_style(
                                 comms, targetID, sat, sat2, envTime
@@ -2926,7 +2475,15 @@ class Environment:
         plt.close(fig)
 
     # TODO: IF REMOVE plot_dynamic_comms, REMOVE THIS
-    def get_edge_style(self, comms, targetID, sat1, sat2, envTime, CI=False):
+    def get_edge_style(
+        self,
+        comms: comms.Comms,
+        targetID: int,
+        sat1: satellite.Satellite,
+        sat2: satellite.Satellite,
+        envTime: float,
+        CI: bool = False,
+    ):
         """
         Helper function to determine the edge style based on communication data.
         Returns 'solid' if both alpha and beta are present, 'dashed' if only one is present,
@@ -2936,9 +2493,18 @@ class Environment:
         if CI:
             return (0, ())
 
-        alpha, beta = comms.total_comm_et_data_values[targetID][sat1.name][sat2.name][
-            envTime
-        ]
+        related_comms = list(
+            filter(
+                lambda x: x.sender == sat1.name
+                and x.receiver == sat2.name
+                and x.target_id == targetID
+                and x.time == envTime,
+                comms.total_comm_et_data,
+            )
+        )
+        assert len(related_comms)
+        assert related_comms[0].data is not None
+        alpha, beta = related_comms[0].data
         if np.isnan(alpha) and np.isnan(beta):
             return (0, (1, 10))
         elif np.isnan(alpha) or np.isnan(beta):

--- a/phase3/estimator.py
+++ b/phase3/estimator.py
@@ -912,13 +912,14 @@ class EtEstimator(BaseEstimator):
                 )
 
                 comms.used_comm_et_data.append(
-                    collection.ArrayTransmission(
+                    collection.MeasurementTransmission(
                         target_id=targetID,
                         sender=sender.name,
                         receiver=sat.name,
                         time=time_sent,
                         size=measVec_size,
-                        data=np.array([alpha, beta]),
+                        alpha=alpha,
+                        beta=beta,
                     )
                 )
 
@@ -1202,14 +1203,22 @@ class EtEstimator(BaseEstimator):
             commonEKF.covarianceHist[targetID][envTime] = cov
             commonEKF.trackErrorHist[targetID][envTime] = self.calcTrackError(est, cov)
 
-    def event_trigger(self, sat, neighbor, targetID, time):
+    def event_trigger(
+        self,
+        sat: 'satellite.Satellite',
+        neighbor: 'satellite.Satellite',
+        targetID: int,
+        time: float,
+    ) -> tuple[float, float]:
         """
         Event Trigger function to determine if an explict or implicit
         measurement update is needed.
 
         Args:
-        - sat (object): Satellite object that is receiving information.
-        - target (object): Target object.
+        - sat: Satellite object that is receiving information.
+        - neighbor: Neighbor satellite object.
+        - targetID: Target ID.
+        - time: Current environment time.
 
         Returns:
         - send_alpha (float): Alpha value to send to neighbor - NaN if not needed.

--- a/phase3/plotting/comms.py
+++ b/phase3/plotting/comms.py
@@ -1,0 +1,96 @@
+import pathlib
+from typing import Sequence
+
+import numpy as np
+from matplotlib import figure
+from matplotlib import pyplot as plt
+
+from phase3 import collection
+from phase3 import target
+
+
+def create_comms_plot(
+    transmissions: Sequence[collection.Transmission],
+    targets: list[target.Target],
+    sat_names: list[str],
+    super_title: str,
+    y_label: str,
+    filename: str,
+    prefix: str | None = None,
+    save: bool = True,
+) -> figure.Figure:
+    # Create a figure
+    fig = plt.figure(figsize=(15, 8))
+    fig.suptitle(super_title, fontsize=14)
+    ax = fig.add_subplot(111)
+
+    prev_data, target_sent_data, target_rec_data = collection.aggregate_transmissions(
+        transmissions,
+        sat_names,
+    )
+
+    count = 0
+    for target in targets:
+        target_id = target.targetID
+        sent_data = target_sent_data[target_id]
+        rec_data = target_rec_data[target_id]
+
+        if not sent_data and not rec_data:
+            continue
+
+        p1 = ax.bar(
+            list(sent_data.keys()),
+            list(sent_data.values()),
+            bottom=list(prev_data.values()),
+            color=target.color,
+        )
+
+        # Add text labels to show which target is which.
+        for i in range(len(sent_data.values())):
+            ax.text(
+                i,
+                list(prev_data.values())[i],
+                target.name,
+                ha='center',
+                va='bottom',
+                color='black',
+            )
+
+        # Add the sent_data values to the prev_data
+        for key in sent_data.keys():
+            prev_data[key] += sent_data[key]
+
+        p2 = ax.bar(
+            list(rec_data.keys()),
+            list(rec_data.values()),
+            bottom=list(prev_data.values()),
+            color=target.color,
+            fill=False,
+            hatch='//',
+            edgecolor=target.color,
+        )
+
+        # Add the rec_data values to the prev_data
+        for key in rec_data.keys():
+            prev_data[key] += rec_data[key]
+
+        count += 1
+        if count == 1:
+            # Add legend
+            ax.legend((p1[0], p2[0]), ('Sent Data', 'Received Data'))
+
+    # Add the labels
+    ax.set_ylabel(y_label)
+
+    # Add the x-axis labels
+    ax.set_xticks(np.arange(len(sat_names)))
+    ax.set_xticklabels(sat_names)
+
+    prefix = f'{prefix}_{filename}' if prefix is not None else filename
+
+    # Save the plot
+    if save:
+        plots_path = pathlib.Path(__file__).parent.parent / 'plots'
+        plt.savefig(plots_path / (prefix + '.png'), dpi=300)
+
+    return fig

--- a/phase3/plotting/comms.py
+++ b/phase3/plotting/comms.py
@@ -1,16 +1,19 @@
 import pathlib
-from typing import Sequence
 
 import numpy as np
 from matplotlib import figure
 from matplotlib import pyplot as plt
 
+from common import dataclassframe
 from phase3 import collection
 from phase3 import target
 
 
 def create_comms_plot(
-    transmissions: Sequence[collection.Transmission],
+    transmissions: (
+        dataclassframe.DataClassFrame[collection.Transmission]
+        | dataclassframe.DataClassFrame[collection.MeasurementTransmission]
+    ),
     targets: list[target.Target],
     sat_names: list[str],
     super_title: str,
@@ -25,7 +28,7 @@ def create_comms_plot(
     ax = fig.add_subplot(111)
 
     prev_data, target_sent_data, target_rec_data = collection.aggregate_transmissions(
-        transmissions,
+        transmissions.to_dataclasses(),
         sat_names,
     )
 

--- a/phase3/satellite.py
+++ b/phase3/satellite.py
@@ -49,7 +49,7 @@ class Satellite:
         # Set the estimators to None on initalization
         self.indeptEstimator: 'estimator.IndeptEstimator | None' = None
         self.ciEstimator: 'estimator.CiEstimator | None' = None
-        self.etEstimators: list['estimator.EtEstimator'] | None = None
+        self.etEstimators: list['estimator.EtEstimator'] = []
 
         self.targPriority: dict[int, int] = {}
         self.targetIDs: list[int] = []
@@ -100,7 +100,7 @@ class Satellite:
             if self.etEstimators:
                 self.update_et_estimator(measurement, target, self.time)
 
-            return collectedFlag
+        return collectedFlag
 
     def update_indept_estimator(
         self, measurement, target: target.Target, time: float
@@ -115,6 +115,7 @@ class Satellite:
             target (object): Target object containing targetID and other relevant information.
             time (float): Current time at which the measurement is taken.
         """
+        assert self.indeptEstimator is not None
         targetID = target.targetID
         if len(self.indeptEstimator.estHist[targetID]) < 1:
             self.indeptEstimator.local_EKF_initialize(target, time)
@@ -137,6 +138,7 @@ class Satellite:
             target (object): Target object containing targetID and other relevant information.
             time (float): Current time at which the measurement is taken.
         """
+        assert self.ciEstimator is not None
         targetID = target.targetID
 
         if (

--- a/phase3/util.py
+++ b/phase3/util.py
@@ -3,12 +3,3 @@ from typing import TypeAlias
 # Map of sim time (minutes) to a map of satellite names to a map of intents,
 # where an intent is a map of target IDs to the accuracy required to track the target.
 CommandersIndent: TypeAlias = dict[int, dict[str, dict[int, int]]]
-
-
-class NestedDict(dict):
-    def __missing__(self, key):
-        value = self[key] = NestedDict()
-        return value
-
-    def __call__(self):
-        return 0


### PR DESCRIPTION
Remove `NestedDict` usage. Its usage was primarily to index measurements / CIs. A database best handles time series data like that, but Pandas dataframes are a close second. We can preserve type hinting by using some neat typing wizardry to allow seamless transfer to/from dataclasses into the dataframes.